### PR TITLE
Show by id route

### DIFF
--- a/deploy/lib/shows.py
+++ b/deploy/lib/shows.py
@@ -46,6 +46,22 @@ class Shows(core.Stack):
 
     def _create_lambdas_config(self):
         self.lambdas_config = {
+            "api-show_by_id": {
+                "layers": ["utils", "databases"],
+                "variables": {
+                    "SHOW_DATABASE_NAME": self.shows_table.table_name,
+                    "LOG_LEVEL": "INFO",
+                },
+                "concurrent_executions": 100,
+                "policies": [
+                    PolicyStatement(
+                        actions=["dynamodb:GetItem"],
+                        resources=[self.shows_table.table_arn]
+                    )
+                ],
+                "timeout": 3,
+                "memory": 128
+            },
             "api-show": {
                 "layers": ["utils", "databases"],
                 "variables": {

--- a/deploy/lib/shows.py
+++ b/deploy/lib/shows.py
@@ -177,6 +177,11 @@ class Shows(core.Stack):
                 "route": "/v1/show",
                 "target_lambda": self.lambdas["api-show"]
             },
+            "get_show_by_id": {
+                "method": "GET",
+                "route": "/v1/show/{id}",
+                "target_lambda": self.lambdas["api-show_by_id"]
+            },
         }
 
         for r in routes:

--- a/src/lambdas/api/show_by_id/__init__.py
+++ b/src/lambdas/api/show_by_id/__init__.py
@@ -1,10 +1,10 @@
 import json
 
-import anime_db
+import show_db
 import decimal_encoder
 import logger
 
-log = logger.get_logger("anime_by_id")
+log = logger.get_logger("show_by_id")
 
 
 class HttpError(object):
@@ -14,9 +14,9 @@ class HttpError(object):
 def handle(event, context):
     log.debug(f"Received event: {event}")
 
-    anime_id = event["pathParameters"].get("id")
+    show_id = event["pathParameters"].get("id")
 
-    res = anime_db.get_anime_by_id(anime_id)
+    res = show_db.get_show_by_id(show_id)
     return {
         "statusCode": 200,
         "body": json.dumps(res, cls=decimal_encoder.DecimalEncoder)

--- a/src/lambdas/api/show_by_id/__init__.py
+++ b/src/lambdas/api/show_by_id/__init__.py
@@ -1,0 +1,23 @@
+import json
+
+import anime_db
+import decimal_encoder
+import logger
+
+log = logger.get_logger("anime_by_id")
+
+
+class HttpError(object):
+    pass
+
+
+def handle(event, context):
+    log.debug(f"Received event: {event}")
+
+    anime_id = event["pathParameters"].get("id")
+
+    res = anime_db.get_anime_by_id(anime_id)
+    return {
+        "statusCode": 200,
+        "body": json.dumps(res, cls=decimal_encoder.DecimalEncoder)
+    }

--- a/test/unittest/test_show_by_id.py
+++ b/test/unittest/test_show_by_id.py
@@ -1,0 +1,33 @@
+import pytest
+
+from api.show_by_id import handle
+
+
+def test_handler(mocked_show_db):
+    exp_item = {
+        "id": "123",
+        "title": "twin peaks",
+    }
+    mocked_show_db.table.get_item.return_value = {"Item": exp_item}
+    event = {
+        "pathParameters": {
+            "id": "123"
+        }
+    }
+
+    res = handle(event, None)
+
+    exp = {'body': '{"id": "123", "title": "twin peaks"}', 'statusCode': 200}
+    assert res == exp
+
+
+def test_handler_not_found(mocked_show_db):
+    mocked_show_db.table.get_item.side_effect = mocked_show_db.NotFoundError
+    event = {
+        "pathParameters": {
+            "ids": "123"
+        }
+    }
+
+    with pytest.raises(mocked_show_db.NotFoundError):
+        handle(event, None)


### PR DESCRIPTION
* Add `GET /v1/shows/{id}` route, will be needed for e.g. calls from watch-history service to check if a show ID exist or not