### PR TITLE
Return 404 instead of 500 if show is not found

### DIFF
--- a/src/lambdas/api/shows_by_id/__init__.py
+++ b/src/lambdas/api/shows_by_id/__init__.py
@@ -16,7 +16,11 @@ def handle(event, context):
 
     show_id = event["pathParameters"].get("id")
 
-    res = shows_db.get_show_by_id(show_id)
+    try:
+        res = shows_db.get_show_by_id(show_id)
+    except shows_db.NotFoundError:
+        return {"statusCode": 404}
+
     return {
         "statusCode": 200,
         "body": json.dumps(res, cls=decimal_encoder.DecimalEncoder)

--- a/test/unittest/test_shows_by_id.py
+++ b/test/unittest/test_shows_by_id.py
@@ -29,5 +29,7 @@ def test_handler_not_found(mocked_shows_db):
         }
     }
 
-    with pytest.raises(mocked_shows_db.NotFoundError):
-        handle(event, None)
+    res = handle(event, None)
+
+    exp = {'statusCode': 404}
+    assert res == exp


### PR DESCRIPTION
* Return 404 instead of 500 for `GET /v1/show/{id}` route