### PR TITLE
Fix consistent get by api

### DIFF
--- a/src/lambdas/api/shows/__init__.py
+++ b/src/lambdas/api/shows/__init__.py
@@ -51,7 +51,13 @@ def _post_show(body):
     try:
         schema.validate_schema(POST_SCHEMA_PATH, body)
     except schema.ValidationException as e:
-        return {"statusCode": 400, "body": json.dumps({"message": "Invalid post schema", "error": str(e)})}
+        return {
+            "statusCode": 400,
+            "body": json.dumps({
+                "message": "Invalid post schema",
+                "error": str(e)
+            })
+        }
 
     if body["api_name"] == "tvmaze":
         return _post_tvmaze(body["api_id"])
@@ -65,14 +71,16 @@ def _post_tvmaze(tvmaze_id):
     else:
         return {
             "statusCode": 200,
-            "body": json.dumps({"id": shows_db.create_show_uuid("tvmaze", tvmaze_id)})
+            "body": json.dumps(
+                {"id": shows_db.create_show_uuid("tvmaze", tvmaze_id)})
         }
 
     shows_db.new_show("tvmaze", int(tvmaze_id))
 
     return {
         "statusCode": 200,
-        "body": json.dumps({"id": shows_db.create_show_uuid("tvmaze", tvmaze_id)})
+        "body": json.dumps(
+            {"id": shows_db.create_show_uuid("tvmaze", tvmaze_id)})
     }
 
 
@@ -83,11 +91,32 @@ def _get_show_by_api_id(query_params):
             "body": json.dumps({"error": "Please specify query parameters"})
         }
 
-    if "tvmaze_id" in query_params:
+    if "api_id" not in query_params:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing api_id query parameter"})
+        }
+
+    if "api_name" not in query_params:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing api_name query parameter"})
+        }
+
+    api_id = int(query_params["api_id"])
+    api_name = query_params["api_name"]
+
+    if api_name in ["tvmaze"]:
         try:
-            res = shows_db.get_show_by_api_id("tvmaze", int(query_params["tvmaze_id"]))
-            return {"statusCode": 200, "body": json.dumps(res, cls=decimal_encoder.DecimalEncoder)}
+            res = shows_db.get_show_by_api_id(api_name, api_id)
+            return {
+                "statusCode": 200,
+                "body": json.dumps(res, cls=decimal_encoder.DecimalEncoder)
+            }
         except shows_db.NotFoundError:
             return {"statusCode": 404}
     else:
-        return {"statusCode": 400, "body": json.dumps({"error": "Unsupported query param"})}
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Unsupported api_name"})
+        }

--- a/test/unittest/test_episodes.py
+++ b/test/unittest/test_episodes.py
@@ -1,200 +1,10 @@
+import copy
 import json
 import pytest
 
 from api.episodes import handle, UnsupportedMethod
 
 TEST_SHOW_UUID = "60223a49-f9ec-4bd8-b90e-23a00cba6a58"
-
-
-def test_post(mocked_shows_db, mocked_episodes_db):
-    mocked_episodes_db.table.query.side_effect = mocked_episodes_db.NotFoundError
-    mocked_shows_db.table.get_item.return_value = {
-        "Item": {
-            "id": TEST_SHOW_UUID
-        }
-    }
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "POST"
-            }
-        },
-        "queryStringParameters": {
-            "id": TEST_SHOW_UUID
-        },
-        "body": '{"api_id": "456", "api_name": "tvmaze"}'
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        "body": json.dumps({"id": "20e10800-b2e2-5079-90b5-243647854ef2"}),
-        "statusCode": 200
-    }
-    assert res == exp
-
-
-def test_post_already_exist(mocked_shows_db, mocked_episodes_db):
-    mocked_episodes_db.table.query.return_value = {
-        "Items": [
-            {
-                "tvmaze_id": "123"
-            }
-        ],
-        "Count": 1
-    }
-    mocked_shows_db.table.get_item.return_value = {
-        "Item": {
-            "id": TEST_SHOW_UUID
-        }
-    }
-
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "POST"
-            }
-        },
-        "queryStringParameters": {
-            "id": TEST_SHOW_UUID
-        },
-        "body": '{"api_id": "456", "api_name": "tvmaze"}'
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        "body": json.dumps({"id": "20e10800-b2e2-5079-90b5-243647854ef2"}),
-        "statusCode": 200
-    }
-    assert res == exp
-
-
-def test_post_no_body(mocked_shows_db, mocked_episodes_db):
-    mocked_episodes_db.table.query.return_value = {
-        "Items": [
-            {
-                "tvmaze_id": "123"
-            },
-        ]
-    }
-    mocked_shows_db.table.get_item.return_value = {
-        "Item": {
-            "id": TEST_SHOW_UUID
-        }
-    }
-
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "POST"
-            }
-        },
-        "queryStringParameters": {
-            "id": TEST_SHOW_UUID
-        },
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        'body': '{"message": "Invalid post body"}',
-        'statusCode': 400
-    }
-    assert res == exp
-
-
-def test_post_invalid_body(mocked_shows_db, mocked_episodes_db):
-    mocked_episodes_db.table.query.return_value = {
-        "Items": [
-            {
-                "mal_id": 123
-            }
-        ]
-    }
-    mocked_shows_db.table.get_item.return_value = {
-        "Item": {
-            "id": TEST_SHOW_UUID
-        }
-    }
-
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "POST"
-            }
-        },
-        "queryStringParameters": {
-            "id": TEST_SHOW_UUID
-        },
-        "body": '{"aa": "bb"}'
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        'body': '{"message": "Invalid post schema", '
-                '"error": "Additional properties are not allowed (\'aa\' was unexpected)"}',
-        'statusCode': 400
-    }
-    assert res == exp
-
-
-def test_post_missing_path_id(mocked_shows_db, mocked_episodes_db):
-    mocked_episodes_db.table.query.return_value = {
-        "Items": [
-            {
-                "mal_id": 123
-            }
-        ]
-    }
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "POST"
-            }
-        },
-        "body": '{"api_id": "456", "api_name": "tvmaze"}'
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        'body': 'Missing id query param',
-        'statusCode': 400
-    }
-    assert res == exp
-
-
-def test_post_show_not_found(mocked_shows_db, mocked_episodes_db):
-    mocked_episodes_db.table.query.return_value = {
-        "Items": [
-            {
-                "mal_id": 123
-            }
-        ]
-    }
-    mocked_shows_db.table.get_item.side_effect = mocked_shows_db.NotFoundError
-
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "POST"
-            }
-        },
-        "queryStringParameters": {
-            "id": TEST_SHOW_UUID
-        },
-        "body": '{"api_id": "456", "api_name": "tvmaze"}'
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        'body': '{"message": "Show not found"}',
-        'statusCode': 404
-    }
-    assert res == exp
 
 
 def test_unsupported_method():
@@ -213,16 +23,149 @@ def test_unsupported_method():
         handle(event, None)
 
 
-def test_get_by_api_id(mocked_shows_db, mocked_episodes_db):
-    exp_res = {
-        "id": "123"
+class TestPost:
+    event = {
+        "requestContext": {
+            "http": {
+                "method": "POST"
+            }
+        },
+        "queryStringParameters": {
+            "id": TEST_SHOW_UUID
+        },
+        "body": '{"api_id": "456", "api_name": "tvmaze"}'
     }
-    mocked_episodes_db.table.query.return_value = {
-        "Items": [
-            exp_res
-        ],
-        "Count": 1
-    }
+
+    def test_success(self, mocked_shows_db, mocked_episodes_db):
+        mocked_episodes_db.table.query.side_effect = mocked_episodes_db.NotFoundError
+        mocked_shows_db.table.get_item.return_value = {
+            "Item": {
+                "id": TEST_SHOW_UUID
+            }
+        }
+
+        res = handle(self.event, None)
+
+        exp = {
+            "body": json.dumps({"id": "20e10800-b2e2-5079-90b5-243647854ef2"}),
+            "statusCode": 200
+        }
+        assert res == exp
+
+    def test_already_exist(self, mocked_shows_db, mocked_episodes_db):
+        mocked_episodes_db.table.query.return_value = {
+            "Items": [
+                {
+                    "tvmaze_id": "123"
+                }
+            ],
+            "Count": 1
+        }
+        mocked_shows_db.table.get_item.return_value = {
+            "Item": {
+                "id": TEST_SHOW_UUID
+            }
+        }
+
+        res = handle(self.event, None)
+
+        exp = {
+            "body": json.dumps({"id": "20e10800-b2e2-5079-90b5-243647854ef2"}),
+            "statusCode": 200
+        }
+        assert res == exp
+
+    def test_no_body(self, mocked_shows_db, mocked_episodes_db):
+        mocked_episodes_db.table.query.return_value = {
+            "Items": [
+                {
+                    "tvmaze_id": "123"
+                },
+            ]
+        }
+        mocked_shows_db.table.get_item.return_value = {
+            "Item": {
+                "id": TEST_SHOW_UUID
+            }
+        }
+
+        event = copy.deepcopy(self.event)
+        del event["body"]
+
+        res = handle(event, None)
+
+        exp = {
+            'body': '{"message": "Invalid post body"}',
+            'statusCode': 400
+        }
+        assert res == exp
+
+    def test_invalid_body(self, mocked_shows_db, mocked_episodes_db):
+        mocked_episodes_db.table.query.return_value = {
+            "Items": [
+                {
+                    "mal_id": 123
+                }
+            ]
+        }
+        mocked_shows_db.table.get_item.return_value = {
+            "Item": {
+                "id": TEST_SHOW_UUID
+            }
+        }
+
+        event = copy.deepcopy(self.event)
+        event["body"] = '{"aa": "bb"}'
+
+        res = handle(event, None)
+
+        exp = {
+            'body': '{"message": "Invalid post schema", '
+                    '"error": "Additional properties are not allowed (\'aa\' was unexpected)"}',
+            'statusCode': 400
+        }
+        assert res == exp
+
+    def test_missing_path_id(self, mocked_shows_db, mocked_episodes_db):
+        mocked_episodes_db.table.query.return_value = {
+            "Items": [
+                {
+                    "mal_id": 123
+                }
+            ]
+        }
+
+        event = copy.deepcopy(self.event)
+        del event["queryStringParameters"]
+
+        res = handle(event, None)
+
+        exp = {
+            'body': 'Missing id query param',
+            'statusCode': 400
+        }
+        assert res == exp
+
+    def test_not_found(self, mocked_shows_db, mocked_episodes_db):
+        mocked_episodes_db.table.query.return_value = {
+            "Items": [
+                {
+                    "mal_id": 123
+                }
+            ]
+        }
+        mocked_shows_db.table.get_item.side_effect = mocked_shows_db.NotFoundError
+
+        res = handle(self.event, None)
+
+        exp = {
+            'body': '{"message": "Show not found"}',
+            'statusCode': 404
+        }
+        assert res == exp
+
+
+class TestGet:
     event = {
         "requestContext": {
             "http": {
@@ -235,73 +178,56 @@ def test_get_by_api_id(mocked_shows_db, mocked_episodes_db):
         }
     }
 
-    res = handle(event, None)
-
-    exp = {
-        "statusCode": 200,
-        "body": json.dumps(exp_res)
-    }
-    assert res == exp
-
-
-def test_get_by_api_id_not_found(mocked_shows_db, mocked_episodes_db):
-    mocked_episodes_db.table.query.side_effect = mocked_episodes_db.NotFoundError
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "GET"
-            }
-        },
-        "queryStringParameters": {
-            "api_id": "123",
-            "api_name": "tvmaze",
+    def test_success(self, mocked_shows_db, mocked_episodes_db):
+        exp_res = {
+            "id": "123"
         }
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        "statusCode": 404,
-    }
-    assert res == exp
-
-
-def test_get_no_query_params():
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "GET"
-            }
-        },
-        "queryStringParameters": {
+        mocked_episodes_db.table.query.return_value = {
+            "Items": [
+                exp_res
+            ],
+            "Count": 1
         }
-    }
 
-    res = handle(event, None)
+        res = handle(self.event, None)
 
-    exp = {
-        "statusCode": 400,
-        "body": json.dumps({"error": "Please specify query parameters"})
-    }
-    assert res == exp
+        exp = {
+            "statusCode": 200,
+            "body": json.dumps(exp_res)
+        }
+        assert res == exp
 
+    def test_not_found(self, mocked_shows_db, mocked_episodes_db):
+        mocked_episodes_db.table.query.side_effect = mocked_episodes_db.NotFoundError
 
-def test_get_invalid_query_params():
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "GET"
-            }
-        },
-        "queryStringParameters": {
+        res = handle(self.event, None)
+
+        exp = {
+            "statusCode": 404,
+        }
+        assert res == exp
+
+    def test_empty_query_params(self):
+        event = copy.deepcopy(self.event)
+        event["queryStringParameters"] = {}
+
+        res = handle(event, None)
+
+        exp = {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Please specify query parameters"})
+        }
+        assert res == exp
+
+    def test_invalid_query_params(self):
+        event = copy.deepcopy(self.event)
+        event["queryStringParameters"] = {
             "abc": "123"
         }
-    }
+        res = handle(event, None)
 
-    res = handle(event, None)
-
-    exp = {
-        "statusCode": 400,
-        "body": json.dumps({"error": "Missing api_id query parameter"})
-    }
-    assert res == exp
+        exp = {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing api_id query parameter"})
+        }
+        assert res == exp

--- a/test/unittest/test_episodes.py
+++ b/test/unittest/test_episodes.py
@@ -231,3 +231,25 @@ class TestGet:
             "body": json.dumps({"error": "Missing api_id query parameter"})
         }
         assert res == exp
+
+    def test_missing_api_name(self):
+        event = copy.deepcopy(self.event)
+        del event["queryStringParameters"]["api_name"]
+        res = handle(event, None)
+
+        exp = {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing api_name query parameter"})
+        }
+        assert res == exp
+
+    def test_invalid_api_name(self):
+        event = copy.deepcopy(self.event)
+        event["queryStringParameters"]["api_name"] = "INVALID"
+        res = handle(event, None)
+
+        exp = {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Unsupported api_name"})
+        }
+        assert res == exp

--- a/test/unittest/test_episodes.py
+++ b/test/unittest/test_episodes.py
@@ -230,7 +230,8 @@ def test_get_by_api_id(mocked_shows_db, mocked_episodes_db):
             }
         },
         "queryStringParameters": {
-            "tvmaze_id": "123"
+            "api_id": "123",
+            "api_name": "tvmaze",
         }
     }
 
@@ -252,7 +253,8 @@ def test_get_by_api_id_not_found(mocked_shows_db, mocked_episodes_db):
             }
         },
         "queryStringParameters": {
-            "tvmaze_id": "123"
+            "api_id": "123",
+            "api_name": "tvmaze",
         }
     }
 
@@ -300,6 +302,6 @@ def test_get_invalid_query_params():
 
     exp = {
         "statusCode": 400,
-        "body": json.dumps({"error": "Unsupported query param"})
+        "body": json.dumps({"error": "Missing api_id query parameter"})
     }
     assert res == exp

--- a/test/unittest/test_shows.py
+++ b/test/unittest/test_shows.py
@@ -1,105 +1,8 @@
+import copy
 import json
 import pytest
 
 from api.shows import handle, UnsupportedMethod
-
-
-def test_post_shows(mocked_shows_db):
-    mocked_shows_db.table.query.side_effect = mocked_shows_db.NotFoundError
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "POST"
-            }
-        },
-        "body": '{"api_id": "123", "api_name": "tvmaze"}'
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        "body": json.dumps({"id": "cf1ffb71-48c3-53c0-9966-900cc5e5553e"}),
-        "statusCode": 200
-    }
-    assert res == exp
-
-
-def test_post_shows_already_exist(mocked_shows_db):
-    mocked_shows_db.table.query.return_value = {
-        "Items": [
-            {
-                "tvmaze_id": "123"
-            }
-        ]
-    }
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "POST"
-            }
-        },
-        "body": '{"api_id": "123", "api_name": "tvmaze"}'
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        "body": json.dumps({"id": "cf1ffb71-48c3-53c0-9966-900cc5e5553e"}),
-        "statusCode": 200
-    }
-    assert res == exp
-
-
-def test_post_shows_no_body(mocked_shows_db):
-    mocked_shows_db.table.query.return_value = {
-        "Items": [
-            {
-                "tvmaze_id": "123"
-            }
-        ]
-    }
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "POST"
-            }
-        },
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        "statusCode": 400,
-        "body": "Invalid post body"
-    }
-    assert res == exp
-
-
-def test_post_shows_invalid_body(mocked_shows_db):
-    mocked_shows_db.table.query.return_value = {
-        "Items": [
-            {
-                "mal_id": 123
-            }
-        ]
-    }
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "POST"
-            }
-        },
-        "body": '{"aa": "bb"}'
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        'body': '{"message": "Invalid post schema", '
-                '"error": "Additional properties are not allowed (\'aa\' was unexpected)"}',
-        'statusCode': 400
-    }
-    assert res == exp
 
 
 def test_unsupported_method():
@@ -118,15 +21,85 @@ def test_unsupported_method():
         handle(event, None)
 
 
-def test_get_by_api_id(mocked_shows_db):
-    exp_res = {
-        "id": "123"
+class TestPost:
+    event = {
+        "requestContext": {
+            "http": {
+                "method": "POST"
+            }
+        },
+        "body": '{"api_id": "123", "api_name": "tvmaze"}'
     }
-    mocked_shows_db.table.query.return_value = {
-        "Items": [
-            exp_res
-        ]
-    }
+
+    def test_success(self, mocked_shows_db):
+        mocked_shows_db.table.query.side_effect = mocked_shows_db.NotFoundError
+
+        res = handle(self.event, None)
+
+        exp = {
+            "body": json.dumps({"id": "cf1ffb71-48c3-53c0-9966-900cc5e5553e"}),
+            "statusCode": 200
+        }
+        assert res == exp
+
+    def test_already_exist(self, mocked_shows_db):
+        mocked_shows_db.table.query.return_value = {
+            "Items": [
+                {
+                    "tvmaze_id": "123"
+                }
+            ]
+        }
+
+        res = handle(self.event, None)
+
+        exp = {
+            "body": json.dumps({"id": "cf1ffb71-48c3-53c0-9966-900cc5e5553e"}),
+            "statusCode": 200
+        }
+        assert res == exp
+
+    def test_no_body(self, mocked_shows_db):
+        mocked_shows_db.table.query.return_value = {
+            "Items": [
+                {
+                    "tvmaze_id": "123"
+                }
+            ]
+        }
+        event = copy.deepcopy(self.event)
+        del event["body"]
+
+        res = handle(event, None)
+
+        exp = {
+            "statusCode": 400,
+            "body": "Invalid post body"
+        }
+        assert res == exp
+
+    def test_invalid_body(self, mocked_shows_db):
+        mocked_shows_db.table.query.return_value = {
+            "Items": [
+                {
+                    "mal_id": 123
+                }
+            ]
+        }
+        event = copy.deepcopy(self.event)
+        event["body"] = '{"aa": "bb"}'
+
+        res = handle(event, None)
+
+        exp = {
+            'body': '{"message": "Invalid post schema", '
+                    '"error": "Additional properties are not allowed (\'aa\' was unexpected)"}',
+            'statusCode': 400
+        }
+        assert res == exp
+
+
+class TestGet:
     event = {
         "requestContext": {
             "http": {
@@ -139,73 +112,56 @@ def test_get_by_api_id(mocked_shows_db):
         }
     }
 
-    res = handle(event, None)
-
-    exp = {
-        "statusCode": 200,
-        "body": json.dumps(exp_res)
-    }
-    assert res == exp
-
-
-def test_get_by_api_id_not_found(mocked_shows_db):
-    mocked_shows_db.table.query.side_effect = mocked_shows_db.NotFoundError
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "GET"
-            }
-        },
-        "queryStringParameters": {
-            "api_id": "123",
-            "api_name": "tvmaze",
+    def test_success(self, mocked_shows_db):
+        exp_res = {
+            "id": "123"
         }
-    }
-
-    res = handle(event, None)
-
-    exp = {
-        "statusCode": 404,
-    }
-    assert res == exp
-
-
-def test_get_no_query_params():
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "GET"
-            }
-        },
-        "queryStringParameters": {
+        mocked_shows_db.table.query.return_value = {
+            "Items": [
+                exp_res
+            ]
         }
-    }
 
-    res = handle(event, None)
+        res = handle(self.event, None)
 
-    exp = {
-        "statusCode": 400,
-        "body": json.dumps({"error": "Please specify query parameters"})
-    }
-    assert res == exp
+        exp = {
+            "statusCode": 200,
+            "body": json.dumps(exp_res)
+        }
+        assert res == exp
 
+    def test_not_found(self, mocked_shows_db):
+        mocked_shows_db.table.query.side_effect = mocked_shows_db.NotFoundError
 
-def test_get_invalid_query_params():
-    event = {
-        "requestContext": {
-            "http": {
-                "method": "GET"
-            }
-        },
-        "queryStringParameters": {
+        res = handle(self.event, None)
+
+        exp = {
+            "statusCode": 404,
+        }
+        assert res == exp
+
+    def test_empty_query_params(self):
+        event = copy.deepcopy(self.event)
+        event["queryStringParameters"] = {}
+
+        res = handle(event, None)
+
+        exp = {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Please specify query parameters"})
+        }
+        assert res == exp
+
+    def test_invalid_query_params(self):
+        event = copy.deepcopy(self.event)
+        event["queryStringParameters"] = {
             "abc": "123"
         }
-    }
 
-    res = handle(event, None)
+        res = handle(event, None)
 
-    exp = {
-        "statusCode": 400,
-        "body": json.dumps({"error": "Missing api_id query parameter"})
-    }
-    assert res == exp
+        exp = {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing api_id query parameter"})
+        }
+        assert res == exp

--- a/test/unittest/test_shows.py
+++ b/test/unittest/test_shows.py
@@ -134,7 +134,8 @@ def test_get_by_api_id(mocked_shows_db):
             }
         },
         "queryStringParameters": {
-            "tvmaze_id": "123"
+            "api_id": "123",
+            "api_name": "tvmaze",
         }
     }
 
@@ -156,7 +157,8 @@ def test_get_by_api_id_not_found(mocked_shows_db):
             }
         },
         "queryStringParameters": {
-            "tvmaze_id": "123"
+            "api_id": "123",
+            "api_name": "tvmaze",
         }
     }
 
@@ -204,6 +206,6 @@ def test_get_invalid_query_params():
 
     exp = {
         "statusCode": 400,
-        "body": json.dumps({"error": "Unsupported query param"})
+        "body": json.dumps({"error": "Missing api_id query parameter"})
     }
     assert res == exp

--- a/test/unittest/test_shows.py
+++ b/test/unittest/test_shows.py
@@ -165,3 +165,25 @@ class TestGet:
             "body": json.dumps({"error": "Missing api_id query parameter"})
         }
         assert res == exp
+
+    def test_missing_api_name(self):
+        event = copy.deepcopy(self.event)
+        del event["queryStringParameters"]["api_name"]
+        res = handle(event, None)
+
+        exp = {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing api_name query parameter"})
+        }
+        assert res == exp
+
+    def test_invalid_api_name(self):
+        event = copy.deepcopy(self.event)
+        event["queryStringParameters"]["api_name"] = "INVALID"
+        res = handle(event, None)
+
+        exp = {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Unsupported api_name"})
+        }
+        assert res == exp


### PR DESCRIPTION
* Use `api_name` and `api_id` query params in `GET /shows` and `GET /episodes` routes